### PR TITLE
refactor: 알림 URL 매핑 리팩토링 및 SSE 로직 변경

### DIFF
--- a/Back-End/src/main/java/net/scit/backend/notification/service/NotificationService.java
+++ b/Back-End/src/main/java/net/scit/backend/notification/service/NotificationService.java
@@ -17,8 +17,12 @@ public interface NotificationService {
     NotificationResponseDTO createAndSendNotification(NotificationEntity notification); // ✅ 추가된 메서드
 
 
-    // 구독은 이제 receiverEmail 기준으로 처리
+    // SSE 구독(Emitter 생성)
     SseEmitter subscribe(String receiverEmail);
+
+    // SSE 구독 해제(Emitter 제거)
+    void unsubscribe(String receiverEmail);
+
 
     NotificationEntity sendNotification(NotificationEntity notification);
 

--- a/Back-End/src/main/java/net/scit/backend/notification/service/impl/NotificationServiceImpl.java
+++ b/Back-End/src/main/java/net/scit/backend/notification/service/impl/NotificationServiceImpl.java
@@ -169,6 +169,7 @@ public class NotificationServiceImpl implements NotificationService {
         }
 
         // ✅ 정상적인 경우 알림 URL 반환
+        log.info("notificationUrl : {}", notificationUrl);
         return notificationUrl;
     }
 

--- a/Back-End/src/main/java/net/scit/backend/notification/service/impl/NotificationServiceImpl.java
+++ b/Back-End/src/main/java/net/scit/backend/notification/service/impl/NotificationServiceImpl.java
@@ -15,7 +15,8 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @RequiredArgsConstructor
@@ -23,33 +24,49 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class NotificationServiceImpl implements NotificationService {
 
     private final NotificationRepository notificationRepository;
-    private final List<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+    // 사용자 이메일을 키로, SseEmitter를 값으로 가지는 맵
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    
+    /**
+     * SSE 구독 (로그인 시 호출)
+     * - 예: 24시간(24 * 60 * 60 * 1000L) 동안 연결 유지
+     */
+    @Override
+    public SseEmitter subscribe(String receiverEmail) {
+        SseEmitter emitter = new SseEmitter(24 * 60 * 60 * 1000L);  // 24시간
+        emitters.put(receiverEmail, emitter);
+
+        emitter.onCompletion(() -> emitters.remove(receiverEmail));
+        emitter.onTimeout(() -> emitters.remove(receiverEmail));
+        emitter.onError(e -> emitters.remove(receiverEmail));
+
+        try {
+            emitter.send(SseEmitter.event().name("INIT").data("SSE 연결 완료"));
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
+        return emitter;
+    }
+
+    
+    /**
+     * SSE 구독 해제 (로그아웃 시 호출)
+     */
+    @Override
+    public void unsubscribe(String receiverEmail) {
+        SseEmitter emitter = emitters.remove(receiverEmail);
+        if (emitter != null) {
+            emitter.complete();
+        }
+    }
 
 
-//    @Override
-//    public void createNotification(String senderEmail, String senderNickname,
-//                                   String receiverEmail, String receiverNickname,
-//                                   Long workspaceId, Long scheduleNumber, Long recordNumber, Long workdataNumber,
-//                                   String notificationName, String notificationType, String notificationContent) {
-//        NotificationEntity notification = new NotificationEntity();
-//        notification.setSenderEmail(senderEmail);
-//        notification.setSenderNickname(senderNickname);
-//        notification.setReceiverEmail(receiverEmail);
-//        notification.setReceiverNickname(receiverNickname);
-//        notification.setWsId(workspaceId);  // workspaceId 설정
-//        notification.setNotificationName(notificationName);
-//        notification.setNotificationType(notificationType);
-//        notification.setNotificationContent(notificationContent);
-//        notification.setNotificationStatus(false);
-//        notification.setNotificationDate(LocalDateTime.now());
-//
-//        // 변경: saveAndFlush() 사용하여 즉시 DB에 반영 및 자동 생성된 notificationNumber 확인
-//        notificationRepository.saveAndFlush(notification); // 변경된 부분
-//        log.info("Notification created with ID: {}", notification.getNotificationNumber()); // 변경 로그
-//
-//        sendNotification(notification);
-//    }
-
+    /**
+     * 알림 생성 & 전송
+     * @param notification
+     * @return
+     */
     @Transactional
     @Override
     public NotificationResponseDTO createAndSendNotification(NotificationEntity notification) {
@@ -63,7 +80,11 @@ public class NotificationServiceImpl implements NotificationService {
         // DTO 변환 후 반환
         return convertToResponseDTO(savedNotification);
     }
-
+    /**
+     * ResponseDTO로 변환
+     * @param notification
+     * @return
+     */
     private NotificationResponseDTO convertToResponseDTO(NotificationEntity notification) {
         return new NotificationResponseDTO(
                 notification.getNotificationNumber(),
@@ -79,42 +100,42 @@ public class NotificationServiceImpl implements NotificationService {
         );
     }
 
-
-    @Override
-    public SseEmitter subscribe(String receiverEmail) {
-        SseEmitter emitter = new SseEmitter(60 * 1000L);
-        emitters.add(emitter);
-
-        emitter.onCompletion(() -> emitters.remove(emitter));
-        emitter.onTimeout(() -> emitters.remove(emitter));
-        emitter.onError(e -> emitters.remove(emitter));
-
-        try {
-            emitter.send(SseEmitter.event().name("INIT").data("SSE 연결 완료"));
-        } catch (IOException e) {
-            emitter.completeWithError(e);
-        }
-        return emitter;
-    }
-
+    /**
+     * 알림 전송
+     * @param notification
+     * @return
+     */
     @Override
     public NotificationEntity sendNotification(NotificationEntity notification) {
-        for (SseEmitter emitter : emitters) {
+        // Map의 entrySet을 순회하여 각 SseEmitter에 알림 전송
+        for (Map.Entry<String, SseEmitter> entry : emitters.entrySet()) {
+            String key = entry.getKey();
+            SseEmitter emitter = entry.getValue();
             try {
                 emitter.send(SseEmitter.event().name("notification").data(notification));
             } catch (IOException e) {
                 emitter.completeWithError(e);
-                emitters.remove(emitter);
+                emitters.remove(key);
             }
         }
         return notification;
     }
 
+    /**
+     * 안 읽은 알림 전체 조회
+     * @param receiverEmail
+     * @return
+     */
     @Override
     public List<NotificationEntity> getUnreadNotifications(String receiverEmail) {
         return notificationRepository.findByReceiverEmailAndNotificationStatusFalseOrderByNotificationDateDesc(receiverEmail);
     }
 
+    /**
+     * 개별 알림 읽음
+     * @param notificationNumber
+     * @return
+     */
     @Override
     public boolean markAsRead(Long notificationNumber) {
         return notificationRepository.findById(notificationNumber).map(notification -> {
@@ -124,6 +145,11 @@ public class NotificationServiceImpl implements NotificationService {
         }).orElse(false);
     }
 
+    /**
+     * 알림 전체 읽음
+     * @param receiverEmail
+     * @return
+     */
     @Override
     public boolean markAllAsRead(String receiverEmail) {
         List<NotificationEntity> unreadNotifications = notificationRepository
@@ -138,6 +164,11 @@ public class NotificationServiceImpl implements NotificationService {
         return true;
     }
 
+    /**
+     * 알림 삭제
+     * @param notificationNumber
+     * @return
+     */
     @Override
     public boolean deleteNotification(Long notificationNumber) {
         if (notificationRepository.existsById(notificationNumber)) {
@@ -147,7 +178,11 @@ public class NotificationServiceImpl implements NotificationService {
         return false;
     }
 
-
+    /**
+     * 알림 url 접속
+     * @param notificationId
+     * @return
+     */
     @Override
     public String getNotificationUrl(Long notificationId) {
         // 현재 로그인한 사용자 이메일 가져오기
@@ -157,20 +192,18 @@ public class NotificationServiceImpl implements NotificationService {
         NotificationEntity notification = notificationRepository.findById(notificationId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
 
-        // 🛑 알림을 받을 권한이 있는지 확인 (알림 수신자와 현재 로그인한 사용자 비교)
+        // 알림을 받을 권한이 있는지 확인 (알림 수신자와 현재 로그인한 사용자 비교)
         if (!notification.getReceiverEmail().equals(currentUserEmail)) {
             throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        // 🛑 URL이 null이거나 빈 문자열인 경우 예외 처리
+        // URL이 null이거나 빈 문자열인 경우 예외 처리
         String notificationUrl = notification.getNotificationUrl();
         if (notificationUrl == null || notificationUrl.isEmpty()) {
             throw new CustomException(ErrorCode.INVALID_NOTIFICATION_URL);
         }
 
-        // ✅ 정상적인 경우 알림 URL 반환
         log.info("notificationUrl : {}", notificationUrl);
         return notificationUrl;
     }
-
 }

--- a/Back-End/src/main/java/net/scit/backend/workdata/controller/WorkdataController.java
+++ b/Back-End/src/main/java/net/scit/backend/workdata/controller/WorkdataController.java
@@ -156,7 +156,7 @@ public class WorkdataController {
     /**
      * 1-4-2) 자료실 개별 조회
      */
-    @GetMapping("/detail/{wsId}/{dataNumber}")
+    @GetMapping("/{wsId}/{dataNumber}")
     public ResponseEntity<ResultDTO<WorkdataTotalSearchDTO>> workdataDetail(
             @PathVariable Long wsId,
             @PathVariable Long dataNumber) {

--- a/Back-End/src/main/java/net/scit/backend/workspace/listener/WorkspaceChannelEventListener.java
+++ b/Back-End/src/main/java/net/scit/backend/workspace/listener/WorkspaceChannelEventListener.java
@@ -36,10 +36,10 @@ public class WorkspaceChannelEventListener {
         switch (event.getEventType()) {
             case "create":
             case "update":
-                notificationUrl = String.format("%s/%d/channel/%d", baseUrl, wsId, channelNumber);
+                notificationUrl = String.format("%s/%d", baseUrl, wsId);
                 break;
             case "delete":
-                notificationUrl = String.format("%s/%d/channel", baseUrl, wsId);
+                notificationUrl = String.format("%s", baseUrl);
                 break;
             default:
                 notificationUrl = baseUrl;


### PR DESCRIPTION
## 🛠️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

<br/>

## 💾 반영 브랜치
ex) jasper-qc-> dev

<br/>

## 👨‍🔧 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
- **AS-IS**
1. workdata 등 일부 알림 관련 url 매핑이 적절하지 않아 수정하였음
(workdata만 테스트하였으며, 나머지 알림 주소는 옳게 설정된 거 같아 따로 테스트는 안 함/ 워크스페이스 채널 제외)
2. SSE 로직 변경
이전: 1분 단위만 지속되었으며, 1분이 끝나면 알림이 안 보내짐
이후: 로그인 시 SSE 구독 & 로그아웃 시 SSE 구독 해제, 재로그인 시 로그아웃 시점부터 재로그인 시점까지의 알림 히스토리를 전부 불러오는 형태

- **TO-BE**
  <br />

## 🎨 이미지 첨부
<!-- 이미지 첨부는 자유 입니다. 하실분은 하시고 안하실 분은 안하셔도 됩니다. -->
<img src="파일주소" width="50%" height="50%"/>
<br/>

## 👨‍💻 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
<br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>
