### PR TITLE
feat: 일정관리 태그 색깔 기능 추가 및 CSS

### DIFF
--- a/Front-End/bibim/vite/package-lock.json
+++ b/Front-End/bibim/vite/package-lock.json
@@ -36,6 +36,7 @@
         "react": "18.3.1",
         "react-apexcharts": "1.4.1",
         "react-beautiful-dnd": "^13.1.1",
+        "react-color": "^2.19.3",
         "react-dom": "18.3.1",
         "react-icons": "^5.5.0",
         "react-perfect-scrollbar": "1.5.8",
@@ -1198,6 +1199,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@icons/material": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
+      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -4993,6 +5003,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
@@ -5045,6 +5061,12 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/material-colors": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
+      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
+      "license": "ISC"
     },
     "node_modules/material-ui-popup-state": {
       "version": "5.3.1",
@@ -5740,6 +5762,24 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/react-color": {
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
+      "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@icons/material": "^0.2.4",
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15",
+        "material-colors": "^1.2.1",
+        "prop-types": "^15.5.10",
+        "reactcss": "^1.2.0",
+        "tinycolor2": "^1.4.1"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -5868,6 +5908,15 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/reactcss": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
+      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.0.1"
       }
     },
     "node_modules/readdirp": {
@@ -6915,6 +6964,12 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
     },
     "node_modules/to-regex-range": {

--- a/Front-End/bibim/vite/package.json
+++ b/Front-End/bibim/vite/package.json
@@ -31,6 +31,7 @@
     "react": "18.3.1",
     "react-apexcharts": "1.4.1",
     "react-beautiful-dnd": "^13.1.1",
+    "react-color": "^2.19.3",
     "react-dom": "18.3.1",
     "react-icons": "^5.5.0",
     "react-perfect-scrollbar": "1.5.8",

--- a/Front-End/bibim/vite/src/api/tag.js
+++ b/Front-End/bibim/vite/src/api/tag.js
@@ -81,33 +81,83 @@ export const fetchSmallTags = async (wsId, largeTagNumber, mediumTagNumber) => {
 };
 
 // ✅ 태그 생성 API
+// export const createTag = async (wsId, tagData) => {
+//   if (!wsId || !tagData.tagName || !tagData.tagType) {
+//     console.warn("🚨 createTag: 필요한 데이터가 없습니다.");
+//     return;
+//   }
+
+//   const payload = { wsId, tagName: tagData.tagName };
+
+//   // 중분류 & 소분류는 부모 태그 정보를 추가
+//   if (tagData.tagType === "medium" && tagData.parentTag) {
+//     payload.largeTagNumber = tagData.parentTag;
+//   } else if (tagData.tagType === "small" && tagData.parentTag && tagData.subParentTag) {
+//     payload.largeTagNumber = tagData.parentTag;
+//     payload.mediumTagNumber = tagData.subParentTag;
+//   }
+
+//   try {
+//     console.log(`📌 createTag(${tagData.tagType}) 요청 데이터:`, payload);
+
+//     await api.post(`/schedule/tag/${tagData.tagType}`, payload, getAxiosConfig());
+
+//     console.log(`✅ 태그(${tagData.tagName}) 생성 성공`);
+//   } catch (error) {
+//     console.error(`❌ createTag 실패:`, error.response?.data || error);
+//     throw error;
+//   }
+// };
+
+// ✅ 태그 생성 API (태그 색깔 포함)
 export const createTag = async (wsId, tagData) => {
   if (!wsId || !tagData.tagName || !tagData.tagType) {
     console.warn("🚨 createTag: 필요한 데이터가 없습니다.");
     return;
   }
 
-  const payload = { wsId, tagName: tagData.tagName };
+  const payload = {
+    wsId,
+    tagName: tagData.tagName
+  };
 
-  // 중분류 & 소분류는 부모 태그 정보를 추가
-  if (tagData.tagType === "medium" && tagData.parentTag) {
-    payload.largeTagNumber = tagData.parentTag;
-  } else if (tagData.tagType === "small" && tagData.parentTag && tagData.subParentTag) {
-    payload.largeTagNumber = tagData.parentTag;
-    payload.mediumTagNumber = tagData.subParentTag;
+  // ✅ 대분류 태그일 경우, tagColor 추가
+  if (tagData.tagType === "large" && tagData.tagColor) {
+    payload.tagColor = tagData.tagColor;
   }
+
+  if (tagData.tagType === "medium") {
+    if (!tagData.largeTagNumber) {
+      console.error("🚨 createTag 오류: 중분류 태그를 생성하려면 largeTagNumber(부모 태그 ID)가 필요합니다.");
+      return;
+    }
+    payload.largeTagNumber = tagData.largeTagNumber;
+  }
+
+  if (tagData.tagType === "small") {
+    if (!tagData.largeTagNumber || !tagData.mediumTagNumber) {
+      console.error("🚨 createTag 오류: 소분류 태그를 생성하려면 부모 태그 정보가 필요합니다.");
+      return;
+    }
+    payload.largeTagNumber = tagData.largeTagNumber;
+    payload.mediumTagNumber = tagData.mediumTagNumber;
+  }
+
+  console.log("📌 최종 API 요청 데이터:", payload); // ✅ 디버깅용 로그
 
   try {
     console.log(`📌 createTag(${tagData.tagType}) 요청 데이터:`, payload);
 
-    await api.post(`/schedule/tag/${tagData.tagType}`, payload, getAxiosConfig());
+    const response = await api.post(`/schedule/tag/${tagData.tagType}`, payload, getAxiosConfig());
 
-    console.log(`✅ 태그(${tagData.tagName}) 생성 성공`);
+    console.log(`✅ 태그(${tagData.tagName}) 생성 성공:`, response.data);
+    return response.data;
   } catch (error) {
     console.error(`❌ createTag 실패:`, error.response?.data || error);
     throw error;
   }
 };
+
 
 // ✅ 대분류 태그 삭제 API
 export const deleteLargeTag = async (largeTagNumber) => {

--- a/Front-End/bibim/vite/src/layout/MainLayout/Sidebar/WorkspaceSelector/index.jsx
+++ b/Front-End/bibim/vite/src/layout/MainLayout/Sidebar/WorkspaceSelector/index.jsx
@@ -112,7 +112,7 @@ const WorkspaceSelector = () => {
                                 variant="outlined"
                                 fullWidth
                                 onClick={handleClick} // 클릭 시 메뉴 열기
-                                sx={{ height: 36, textTransform: 'none' }}
+                                sx={{ height: 36, textTransform: 'none', }}
                                 disabled={loading} // 로딩 중일 때 비활성화
                             >
                                 {loading ? '로딩 중...' : '워크스페이스 변경'}

--- a/Front-End/bibim/vite/src/views/schedule/components/Calendar.jsx
+++ b/Front-End/bibim/vite/src/views/schedule/components/Calendar.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
-import { Box } from '@mui/material';
+import { Box, Avatar } from '@mui/material';
 import styled from '@emotion/styled';
 import ScheduleDetailModal from './ScheduleDetailModal';
 import ScheduleEditModal from './ScheduleEditModal';
@@ -155,32 +155,75 @@ const Calendar = ({ tasks, onDeleteSuccess }) => {
             const scheduleId = info.event.id;
             info.el.setAttribute('data-schedule-id', scheduleId);
 
+            // ✅ extendedProps에 color 값이 있으면 해당 색상 적용
+            const eventColor = info.event.extendedProps.color || '#3788d8'; // 기본값: 파란색
+            info.el.style.backgroundColor = eventColor;
+            info.el.style.borderColor = eventColor; // 테두리 색상도 동일하게 설정
+            info.el.style.color = 'white'; // 텍스트 가독성을 위해 흰색으로 설정
+
             info.el.addEventListener('mouseenter', () => handleEventHover(scheduleId, true));
             info.el.addEventListener('mouseleave', () => handleEventHover(scheduleId, false));
           }}
-          eventContent={(arg) => (
-            <Box
-              sx={{
-                '& .fc-daygrid-event-harness': {
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: '4px', // ✅ 이벤트 간 간격 확보 (margin 없이!)
-                },
-                '& .fc-daygrid-event': {
-                  padding: '4px', // ✅ 내부 간격 조정 (이벤트 높이 변화 없음)
-                  borderRadius: '5px', // ✅ 둥근 테두리
-                  fontSize: '13px', // ✅ 폰트 크기 조정
-                },
-                '& .fc-event-title': {
-                  lineHeight: '1.2', // ✅ 글자 높이 조정
-                },
-              }}
-            >
+          // eventContent={(arg) => (
+          //   <Box
+          //     sx={{
+          //       '& .fc-daygrid-event-harness': {
+          //         display: 'flex',
+          //         flexDirection: 'column',
+          //         gap: '4px', // ✅ 이벤트 간 간격 확보 (margin 없이!)
+          //       },
+          //       '& .fc-daygrid-event': {
+          //         padding: '4px', // ✅ 내부 간격 조정 (이벤트 높이 변화 없음)
+          //         borderRadius: '5px', // ✅ 둥근 테두리
+          //         fontSize: '13px', // ✅ 폰트 크기 조정
+          //       },
+          //       '& .fc-event-title': {
+          //         lineHeight: '1.2', // ✅ 글자 높이 조정
+          //       },
+          //     }}
+          //   >
 
-              {arg.event.title}
-            </Box>
-          )}
+          //     {arg.event.title}
+          //   </Box>
+          // )}
+          /** ✅ 일정 내부 텍스트 및 프로필 이미지 추가 */
+          eventContent={(arg) => {
+            const { scheduleStatus, profileImage } = arg.event.extendedProps;
+
+            return (
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '4px', // ✅ 텍스트와 이미지 사이 간격
+                  backgroundColor: arg.event.extendedProps.color || '#3788d8',
+                  color: 'white',
+                  borderRadius: '5px',
+                  padding: '2px 6px',
+                  fontSize: '13px',
+                  lineHeight: '1.2',
+                }}
+              >
+                {/* ✅ 일정 제목 */}
+                <span>{arg.event.title}</span>
+
+                {/* ✅ UNASSIGNED가 아닐 경우 프로필 이미지 표시 */}
+                {scheduleStatus !== 'UNASSIGNED' && (
+                  <Avatar
+                    src={profileImage || ''}
+                    sx={{
+                      width: 14, // 🔹 엄청 작은 크기
+                      height: 14,
+                      border: '1px solid white',
+                      backgroundColor: profileImage ? 'transparent' : 'gray', // 이미지가 없을 경우 기본 회색 원형
+                    }}
+                  />
+                )}
+              </Box>
+            );
+          }}
         />
+
         <ScheduleDetailModal
           open={modalOpen}
           onClose={() => {

--- a/Front-End/bibim/vite/src/views/schedule/components/KanbanBoard.jsx
+++ b/Front-End/bibim/vite/src/views/schedule/components/KanbanBoard.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Box, Card, Typography } from "@mui/material";
+import { Box, Card, Typography, Avatar } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { fetchKanbanTasks, fetchScheduleTasks, updateKanbanTaskStatus, assignSchedule } from "../../../api/schedule";
@@ -33,6 +33,13 @@ const columns = {
   inProgress: "진행 중",
   completed: "완료",
   backlog: "보류",
+};
+
+const columnColors = {
+  unassigned: "#ECF2FF", // 할 일
+  inProgress: "#E8F7FF", // 진행 중
+  completed: "#FEF5E5", // 완료
+  backlog: "#E6FFFA", // 보류
 };
 
 const KanbanBoard = ({ wsId, setSchedules, setGanttTasks }) => {
@@ -149,7 +156,8 @@ const KanbanBoard = ({ wsId, setSchedules, setGanttTasks }) => {
 
   return (
     <KanbanWrapper>
-      <h2>📌 칸반 보드 (wsId: {wsId})</h2>
+      {/* <h2>📌 칸반 보드 (wsId: {wsId})</h2> */}
+      <h2>📌 칸반 보드</h2>
       <DragDropContext onDragEnd={onDragEnd}>
         <Box display="flex" justifyContent="space-around">
           {Object.entries(columns).map(([columnId, columnTitle]) => (
@@ -162,11 +170,20 @@ const KanbanBoard = ({ wsId, setSchedules, setGanttTasks }) => {
                     width: "250px",
                     minHeight: "400px",
                     padding: "10px",
-                    backgroundColor: "#f4f4f4",
+                    backgroundColor: columnColors[columnId],
                     borderRadius: "8px",
                   }}
                 >
-                  <Typography variant="h6" align="center" gutterBottom>
+                  <Typography
+                    variant="h4"
+                    align="center"
+                    gutterBottom
+                    sx={{
+                      fontWeight: "bold",
+                      marginBottom: "20px",
+                      marginTop: "5px",
+                    }}
+                  >
                     {columnTitle}
                   </Typography>
                   {tasks
@@ -181,8 +198,25 @@ const KanbanBoard = ({ wsId, setSchedules, setGanttTasks }) => {
                             ref={provided.innerRef}
                             {...provided.draggableProps}
                             {...provided.dragHandleProps}
-                            sx={{ marginBottom: "10px", padding: "10px" }}
+                            sx={{
+                              marginBottom: "10px",
+                              padding: "10px",
+                              boxShadow: "0 0 10px rgba(0,0,0,0.1)",
+                              display: "flex",
+                              alignItems: "center",
+                              gap: "10px"
+                            }}
                           >
+                            {task.extendedProps?.profileImage && (
+                              <Avatar
+                                src={task.extendedProps.profileImage}
+                                alt={task.extendedProps.nickname}
+                                sx={{
+                                  width: "30px",
+                                  height: "30px",
+                                }}
+                              />
+                            )}
                             <Typography>{task.title}</Typography>
                           </Card>
                         )}

--- a/Front-End/bibim/vite/yarn.lock
+++ b/Front-End/bibim/vite/yarn.lock
@@ -426,6 +426,11 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz"
   integrity sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==
 
+"@icons/material@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz"
+  integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz"
@@ -2275,7 +2280,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@4.17.21:
+lodash-es@^4.17.15, lodash-es@4.17.21:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
@@ -2284,6 +2289,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash@^4.0.1, lodash@^4.17.15:
+  version "4.17.21"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -2315,6 +2325,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+material-colors@^1.2.1:
+  version "1.2.6"
+  resolved "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz"
+  integrity sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==
 
 material-ui-popup-state@5.3.1:
   version "5.3.1"
@@ -2612,7 +2627,7 @@ prettier@>=3.0.0, prettier@3.4.1:
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.4.1.tgz"
   integrity sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==
 
-prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.5.10, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -2665,6 +2680,19 @@ react-beautiful-dnd@^13.1.1:
     react-redux "^7.2.0"
     redux "^4.0.4"
     use-memo-one "^1.1.1"
+
+react-color@^2.19.3:
+  version "2.19.3"
+  resolved "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz"
+  integrity sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==
+  dependencies:
+    "@icons/material" "^0.2.4"
+    lodash "^4.17.15"
+    lodash-es "^4.17.15"
+    material-colors "^1.2.1"
+    prop-types "^15.5.10"
+    reactcss "^1.2.0"
+    tinycolor2 "^1.4.1"
 
 "react-dom@^16.7.0 || ^17 || ^18 || ^19", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^16.8.5 || ^17.0.0 || ^18.0.0", "react-dom@^17.0.0 || ^18.0.0 || ^19.0.0", react-dom@^18.0.0, react-dom@>=16.3.3, react-dom@>=16.6.0, react-dom@>=16.8.0, react-dom@>=18, react-dom@18.3.1:
   version "18.3.1"
@@ -2770,6 +2798,13 @@ react@*, "react@^16.11.0 || ^17.0.0 || ^18.0.0", "react@^16.7.0 || ^17 || ^18 ||
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
   dependencies:
     loose-envify "^1.1.0"
+
+reactcss@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz"
+  integrity sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==
+  dependencies:
+    lodash "^4.0.1"
 
 readdirp@^4.0.1:
   version "4.1.1"
@@ -3361,6 +3396,11 @@ tiny-invariant@^1.0.6:
   version "1.3.3"
   resolved "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
+
+tinycolor2@^1.4.1:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz"
+  integrity sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==
 
 to-regex-range@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
## 🛠️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

<br/>

## 💾 반영 브랜치
feat/front_detailjob -> dev

<br/>

## 👨‍🔧 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
- **AS-IS**
- react-color 추가
- 대분류 태그 생성시 색깔 추가 기능 (색깔 픽 - 기본 6색 및 임의의 지정색)
- 일정관리 캘린더뷰일때 태그 색깔에 따른 일정 렌더링 및 담당자 아바타 추가
- 칸반보드 CSS 추가

- **TO-BE**
  <br />

## 🎨 이미지 첨부
<!-- 이미지 첨부는 자유 입니다. 하실분은 하시고 안하실 분은 안하셔도 됩니다. -->
<img src="파일주소" width="50%" height="50%"/>
<br/>

## 👨‍💻 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트
<br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>
