### PR TITLE
Feat: 읽은/안 읽은 알림 전체 삭제 관련 백,프론트 구현 외 리팩토링 1건

### DIFF
--- a/Back-End/src/main/java/net/scit/backend/config/SecurityConfig.java
+++ b/Back-End/src/main/java/net/scit/backend/config/SecurityConfig.java
@@ -71,7 +71,8 @@ public class SecurityConfig {
                         .hasRole("USER") // 사용자 전용
                         .requestMatchers("/notification/{notificationId}", "/notification/subscribe").permitAll() // ✅ SSE 및 리다이렉트 허용
                         .requestMatchers("/notification/unread", "/notification/read-single",
-                                "/notification/read-all", "/notification/delete")
+                                        "/notification/read-all", "/notification/delete",
+                                        "/notification/delete-unread", "/notification/delete-read")
                         .authenticated() // ✅ 알림 관련 API는 인증 필요
                         .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
                 )

--- a/Back-End/src/main/java/net/scit/backend/member/listener/MemberEventListener.java
+++ b/Back-End/src/main/java/net/scit/backend/member/listener/MemberEventListener.java
@@ -40,7 +40,7 @@ public class MemberEventListener {
         notification.setNotificationStatus(false);
         notification.setNotificationDate(LocalDateTime.now());
         // 모든 회원 관련 알림은 회원정보 페이지로 이동하도록 고정
-        notification.setNotificationUrl("http://localhost:3000/mypage");
+        notification.setNotificationUrl("https://api.bibim.shop/mypage");
 
         // 2) 저장 + 실시간 전송 (Map 기반 SSE)
         //    NotificationServiceImpl 내 createAndSendNotification()에서

--- a/Back-End/src/main/java/net/scit/backend/notification/controller/NotificationController.java
+++ b/Back-End/src/main/java/net/scit/backend/notification/controller/NotificationController.java
@@ -110,6 +110,22 @@ public class NotificationController {
     }
 
 
+    @DeleteMapping("/delete-read")
+    public ResponseEntity<String> deleteAllReadNotifications(@RequestHeader("Authorization") String token) {
+        String email = AuthUtil.getLoginUserId();
+        boolean result = notificationService.deleteAllRead(email);
+        return result ? ResponseEntity.ok("읽은 알림 전체 삭제 완료")
+                : ResponseEntity.badRequest().body("삭제할 읽은 알림이 없습니다.");
+    }
+
+    @DeleteMapping("/delete-unread")
+    public ResponseEntity<String> deleteAllUnreadNotifications(@RequestHeader("Authorization") String token) {
+        String email = AuthUtil.getLoginUserId();
+        boolean result = notificationService.deleteAllUnread(email);
+        return result ? ResponseEntity.ok("안 읽은 알림 전체 삭제 완료")
+                : ResponseEntity.badRequest().body("삭제할 안 읽은 알림이 없습니다.");
+    }
+
     @GetMapping("/{notificationId}")
     public ResponseEntity<Void> redirectToNotificationUrl(@PathVariable Long notificationId) {
         String url = notificationService.getNotificationUrl(notificationId);
@@ -117,4 +133,6 @@ public class NotificationController {
         headers.add("Location", url);
         return new ResponseEntity<>(headers, HttpStatus.FOUND);
     }
+
+
 }

--- a/Back-End/src/main/java/net/scit/backend/notification/service/NotificationService.java
+++ b/Back-End/src/main/java/net/scit/backend/notification/service/NotificationService.java
@@ -35,6 +35,12 @@ public interface NotificationService {
 
     boolean deleteNotification(Long notificationNumber);
 
+    // 읽은 알림 전체 삭제
+    boolean deleteAllRead(String receiverEmail);
+
+    // 안 읽은 알림 전체 삭제
+    boolean deleteAllUnread(String receiverEmail);
+
     // 알림 URL 조회 (리다이렉트용)
     String getNotificationUrl(Long notificationId);
 }

--- a/Back-End/src/main/java/net/scit/backend/notification/service/impl/NotificationServiceImpl.java
+++ b/Back-End/src/main/java/net/scit/backend/notification/service/impl/NotificationServiceImpl.java
@@ -142,6 +142,33 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
 
+    @Transactional
+    @Override
+    public boolean deleteAllRead(String receiverEmail) {
+        List<NotificationEntity> readNotifications =
+                notificationRepository.findByReceiverEmailAndNotificationStatusTrueOrderByNotificationDateDesc(receiverEmail);
+        if (readNotifications.isEmpty()) {
+            return false;
+        }
+        notificationRepository.deleteAll(readNotifications);
+        log.info("읽은 알림 전체 삭제 완료, 삭제 개수: {}", readNotifications.size());
+        return true;
+    }
+
+    @Transactional
+    @Override
+    public boolean deleteAllUnread(String receiverEmail) {
+        List<NotificationEntity> unreadNotifications =
+                notificationRepository.findByReceiverEmailAndNotificationStatusFalseOrderByNotificationDateDesc(receiverEmail);
+        if (unreadNotifications.isEmpty()) {
+            return false;
+        }
+        notificationRepository.deleteAll(unreadNotifications);
+        log.info("안 읽은 알림 전체 삭제 완료, 삭제 개수: {}", unreadNotifications.size());
+        return true;
+    }
+
+
     @Override
     public String getNotificationUrl(Long notificationId) {
         NotificationEntity notification = notificationRepository.findById(notificationId)

--- a/Back-End/src/main/java/net/scit/backend/schedule/listener/ScheduleEventListener.java
+++ b/Back-End/src/main/java/net/scit/backend/schedule/listener/ScheduleEventListener.java
@@ -32,8 +32,7 @@ public class ScheduleEventListener {
                 event.getEventType(), workspaceId, notificationMessage);
 
         // 모든 경우에 동일한 URL 설정
-        final String baseUrl = "http://localhost:3000/schedule";
-        String notificationUrl = baseUrl;
+        final String baseUrl = "https://dev.bibim.shop/schedule";
 
         // 특정 워크스페이스의 모든 멤버 조회
         List<WorkspaceMemberEntity> workspaceMembers =
@@ -41,7 +40,7 @@ public class ScheduleEventListener {
 
         // 각 워크스페이스 멤버에게 알림 전송
         workspaceMembers.forEach(member -> {
-            NotificationEntity notification = buildNotificationEntity(event, member, workspaceId, notificationMessage, notificationUrl);
+            NotificationEntity notification = buildNotificationEntity(event, member, workspaceId, notificationMessage, baseUrl);
             NotificationResponseDTO response = notificationService.createAndSendNotification(notification);
             log.info("📢 알림 전송 및 저장 완료 - NotificationNumber: {}", response.getNotificationNumber());
         });

--- a/Back-End/src/main/java/net/scit/backend/workdata/listener/WorkdataEventListener.java
+++ b/Back-End/src/main/java/net/scit/backend/workdata/listener/WorkdataEventListener.java
@@ -31,7 +31,7 @@ public class WorkdataEventListener {
         log.info("📢 Workdata 이벤트 감지: {} | 워크스페이스 ID: {} | 메시지: {}",
                 event.getEventType(), workspaceId, notificationMessage);
 
-        final String notificationUrl = "http://localhost:3000/workdata";
+        final String notificationUrl = "https://dev.bibim.shop/workdata";
 
 
         // 특정 워크스페이스의 모든 멤버 조회

--- a/Back-End/src/main/java/net/scit/backend/workspace/listener/WorkspaceChannelEventListener.java
+++ b/Back-End/src/main/java/net/scit/backend/workspace/listener/WorkspaceChannelEventListener.java
@@ -32,7 +32,7 @@ public class WorkspaceChannelEventListener {
                 event.getEventType(), workspaceId, notificationMessage);
 
         // 모든 경우에 대해 동일한 URL로 리다이렉트: http://localhost:3000/channel
-        String notificationUrl = "http://localhost:3000/channel";
+        String notificationUrl = "https://dev.bibim.shop/channel";
 
         List<WorkspaceMemberEntity> workspaceMembers =
                 workspaceMemberRepository.findMembersByWorkspaceIdNative(workspaceId);

--- a/Back-End/src/main/java/net/scit/backend/workspace/listener/WorkspaceEventListener.java
+++ b/Back-End/src/main/java/net/scit/backend/workspace/listener/WorkspaceEventListener.java
@@ -25,8 +25,8 @@ public class WorkspaceEventListener {
 
         // 이벤트 유형에 따라 URL 결정
         String notificationUrl = switch (event.getEventType()) {
-            case "grant", "role_update" -> "http://localhost:3000/ws-setting";
-            default -> "http://localhost:3000/ws-select";
+            case "grant", "role_update" -> "https://dev.bibim.shop/ws-setting";
+            default -> "https://dev.bibim.shop/ws-select";
         };
 
         log.info("📢 이벤트 감지: {} | 대상자: {} | 내용: {} | URL: {}",

--- a/Front-End/bibim/vite/src/layout/MainLayout/Header/NotificationSection/index.jsx
+++ b/Front-End/bibim/vite/src/layout/MainLayout/Header/NotificationSection/index.jsx
@@ -86,16 +86,16 @@ export default function NotificationSection() {
     try {
       const token = localStorage.getItem("token");
       const response = await fetch(
-          `${API_BASE_URL}/notification/read-single?notificationNumber=${notificationId}`,
-          {
-            method: 'POST',
-            headers: { 'Authorization': `Bearer ${token}` }
-          }
+        `${API_BASE_URL}/notification/read-single?notificationNumber=${notificationId}`,
+        {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${token}` }
+        }
       );
       if (response.ok) {
         // 읽음 처리 성공 시, 목록에서 제거
         setNotifications((prev) =>
-            prev.filter((n) => n.notificationNumber !== notificationId)
+          prev.filter((n) => n.notificationNumber !== notificationId)
         );
         setUnreadCount((prevCount) => Math.max(prevCount - 1, 0));
       } else {
@@ -117,7 +117,7 @@ export default function NotificationSection() {
       });
       if (response.ok) {
         setNotifications((prev) =>
-            prev.filter((n) => n.notificationNumber !== notificationId)
+          prev.filter((n) => n.notificationNumber !== notificationId)
         );
       } else {
         console.error('❌ 알림 삭제 실패:', response.status);
@@ -126,6 +126,45 @@ export default function NotificationSection() {
       console.error('❌ 알림 삭제 중 오류 발생:', error);
     }
   };
+
+
+  // 안 읽은 알림 전체 삭제 및 unreadCount 초기화
+  const deleteAllUnreadNotifications = async () => {
+    try {
+      const token = localStorage.getItem("token")?.trim();
+      const response = await fetch(`${API_BASE_URL}/notification/delete-unread`, {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      if (response.ok) {
+        setNotifications([]);   // 알림 목록 초기화
+        setUnreadCount(0);        // unreadCount 초기화
+      } else {
+        console.error("❌ 안 읽은 알림 전체 삭제 실패:", response.status);
+      }
+    } catch (error) {
+      console.error("❌ 안 읽은 알림 전체 삭제 중 오류 발생:", error);
+    }
+  };
+
+  // 읽은 알림 전체 삭제
+  const deleteAllReadNotifications = async () => {
+    try {
+      const token = localStorage.getItem("token")?.trim();
+      const response = await fetch(`${API_BASE_URL}/notification/delete-read`, {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      if (response.ok) {
+        setNotifications([]);  // 알림 목록 초기화 (혹은 원하는 방식으로 갱신)
+      } else {
+        console.error("❌ 읽은 알림 전체 삭제 실패:", response.status);
+      }
+    } catch (error) {
+      console.error("❌ 읽은 알림 전체 삭제 중 오류 발생:", error);
+    }
+  };
+
 
 
   // 전체 읽기 시 unreadCount 즉시 0으로 변경
@@ -139,7 +178,7 @@ export default function NotificationSection() {
 
       if (response.ok) {
         setNotifications((prev) =>
-            prev.map((n) => ({ ...n, notificationStatus: true }))
+          prev.map((n) => ({ ...n, notificationStatus: true }))
         );
         setUnreadCount(0);
       }
@@ -263,127 +302,138 @@ export default function NotificationSection() {
 
 
   return (
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-        {/* ✅ 알림 아이콘을 감싸는 박스 (위치 조정) */}
-        <Box sx={{ position: 'relative', mr: 2 }}>
-          {/* ✅ 알림 아이콘 */}
-          <Avatar
-              variant="rounded"
-              sx={{
-                transition: 'all .2s ease-in-out',
-                bgcolor: 'secondary.light',
-                color: 'secondary.dark',
-                '&:hover': { bgcolor: 'secondary.dark', color: 'secondary.light' }
-              }}
-              ref={anchorRef}
-              aria-controls={open ? 'menu-list-grow' : undefined}
-              aria-haspopup="true"
-              onClick={handleToggle}
-          >
-            <IconBell stroke={1.5} size="20px" />
-          </Avatar>
-
-          {/* ✅ 읽지 않은 알림 개수 표시 */}
-          {unreadCount > 0 && (
-              <Box
-                  sx={{
-                    position: 'absolute',
-                    top: 0,
-                    right: 0,
-                    width: 18,
-                    height: 18,
-                    bgcolor: 'error.main', // 빨간색 배경
-                    color: 'white', // 하얀색 숫자
-                    fontSize: '12px',
-                    fontWeight: 'bold',
-                    borderRadius: '50%', // 원형 모양
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    transform: 'translate(50%, -50%)' // 위치 미세 조정
-                  }}
-              >
-                {unreadCount}
-              </Box>
-          )}
-        </Box>
-
-        {/* ✅ Popper (알림 목록 팝업) */}
-        <Popper
-            placement={downMD ? 'bottom' : 'bottom-end'}
-            open={open}
-            anchorEl={anchorRef.current}
-            role={undefined}
-            transition
-            disablePortal
-            modifiers={[{ name: 'offset', options: { offset: [downMD ? 5 : 0, 20] } }]}
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+      {/* ✅ 알림 아이콘을 감싸는 박스 (위치 조정) */}
+      <Box sx={{ position: 'relative', mr: 2 }}>
+        {/* ✅ 알림 아이콘 */}
+        <Avatar
+          variant="rounded"
+          sx={{
+            transition: 'all .2s ease-in-out',
+            bgcolor: 'secondary.light',
+            color: 'secondary.dark',
+            '&:hover': { bgcolor: 'secondary.dark', color: 'secondary.light' }
+          }}
+          ref={anchorRef}
+          aria-controls={open ? 'menu-list-grow' : undefined}
+          aria-haspopup="true"
+          onClick={handleToggle}
         >
-          {({ TransitionProps }) => (
-              <ClickAwayListener onClickAway={handleClose}>
-                <Transitions position={downMD ? 'top' : 'top-right'} in={open} {...TransitionProps}>
-                  <Paper sx={{ width: '50vw', height: '50vh' }}>
-                    {open && (
-                        <MainCard border={false} elevation={16} content={false} boxShadow shadow={theme.shadows[16]}>
-                          <Grid container direction="column" spacing={2}>
-                            {/* Header: "내 알림" & unread count */}
-                            <Grid item xs={12}>
-                              <Grid container sx={{ alignItems: 'center', justifyContent: 'space-between', pt: 2, px: 2 }}>
-                                <Grid item>
-                                  <Stack direction="row" spacing={2}>
-                                    <Typography variant="subtitle1">내 알림</Typography>
-                                    <Chip size="small" label={unreadCount} sx={{ color: 'background.default', bgcolor: 'warning.dark' }} />
-                                  </Stack>
-                                </Grid>
-                              </Grid>
-                            </Grid>
+          <IconBell stroke={1.5} size="20px" />
+        </Avatar>
 
-                            {/* Filter Select */}
-                            <Grid item xs={12}>
-                              <Box sx={{ px: 2, pt: 0.25 }}>
-                                <TextField
-                                    select
-                                    fullWidth
-                                    value={filterValue}
-                                    onChange={handleChange} // ✅ handleChange로 변경
-                                    slotProps={{ select: { native: true } }}
-                                >
-                                  {statusOptions.map((option) => (
-                                      <option key={option.value} value={option.value}>
-                                        {option.label}
-                                      </option>
-                                  ))}
-                                </TextField>
-
-                              </Box>
-                            </Grid>
-                            <Grid item xs={12}>
-                              <Box sx={{ height: '30vh', overflowY: 'auto' }}>
-                                <NotificationList
-                                    notifications={notifications}
-                                    onNotificationClick={handleNotificationClick}
-                                    onMarkAsRead={markNotificationAsRead}
-                                    onDeleteNotification={deleteNotification}
-                                />
-                              </Box>
-                            </Grid>
-
-                            {/* Bottom: 전체 알림 읽기 & Load More */}
-                            <Grid item xs={12}>
-                              <Box sx={{ textAlign: 'center', pb: 1 }}>
-                                <Button size="small" disableElevation onClick={markAllNotificationsAsRead}>
-                                  전체 알림 읽기
-                                </Button>
-                              </Box>
-                            </Grid>
-                          </Grid>
-                        </MainCard>
-                    )}
-                  </Paper>
-                </Transitions>
-              </ClickAwayListener>
-          )}
-        </Popper>
+        {/* ✅ 읽지 않은 알림 개수 표시 */}
+        {unreadCount > 0 && (
+          <Box
+            sx={{
+              position: 'absolute',
+              top: 0,
+              right: 0,
+              width: 18,
+              height: 18,
+              bgcolor: 'error.main', // 빨간색 배경
+              color: 'white', // 하얀색 숫자
+              fontSize: '12px',
+              fontWeight: 'bold',
+              borderRadius: '50%', // 원형 모양
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              transform: 'translate(50%, -50%)' // 위치 미세 조정
+            }}
+          >
+            {unreadCount}
+          </Box>
+        )}
       </Box>
+
+      {/* ✅ Popper (알림 목록 팝업) */}
+      <Popper
+        placement={downMD ? 'bottom' : 'bottom-end'}
+        open={open}
+        anchorEl={anchorRef.current}
+        role={undefined}
+        transition
+        disablePortal
+        modifiers={[{ name: 'offset', options: { offset: [downMD ? 5 : 0, 20] } }]}
+      >
+        {({ TransitionProps }) => (
+          <ClickAwayListener onClickAway={handleClose}>
+            <Transitions position={downMD ? 'top' : 'top-right'} in={open} {...TransitionProps}>
+              <Paper sx={{ width: '50vw', height: '50vh' }}>
+                {open && (
+                  <MainCard border={false} elevation={16} content={false} boxShadow shadow={theme.shadows[16]}>
+                    <Grid container direction="column" spacing={2}>
+                      {/* Header: "내 알림" & unread count */}
+                      <Grid item xs={12}>
+                        <Grid container sx={{ alignItems: 'center', justifyContent: 'space-between', pt: 2, px: 2 }}>
+                          <Grid item>
+                            <Stack direction="row" spacing={2}>
+                              <Typography variant="subtitle1">내 알림</Typography>
+                              <Chip size="small" label={unreadCount} sx={{ color: 'background.default', bgcolor: 'warning.dark' }} />
+                            </Stack>
+                          </Grid>
+                        </Grid>
+                      </Grid>
+
+                      {/* Filter Select */}
+                      <Grid item xs={12}>
+                        <Box sx={{ px: 2, pt: 0.25 }}>
+                          <TextField
+                            select
+                            fullWidth
+                            value={filterValue}
+                            onChange={handleChange} // ✅ handleChange로 변경
+                            slotProps={{ select: { native: true } }}
+                          >
+                            {statusOptions.map((option) => (
+                              <option key={option.value} value={option.value}>
+                                {option.label}
+                              </option>
+                            ))}
+                          </TextField>
+
+                        </Box>
+                      </Grid>
+                      <Grid item xs={12}>
+                        <Box sx={{ height: '30vh', overflowY: 'auto' }}>
+                          <NotificationList
+                            notifications={notifications}
+                            onNotificationClick={handleNotificationClick}
+                            onMarkAsRead={markNotificationAsRead}
+                            onDeleteNotification={deleteNotification}
+                          />
+                        </Box>
+                      </Grid>
+
+                      {/* Bottom: 버튼 영역 */}
+                      <Grid item xs={12}>
+                        <Box sx={{ textAlign: 'center', pb: 1, display: 'flex', gap: 1, justifyContent: 'center' }}>
+                          {filterValue === "unread" ? (
+                            <>
+                              <Button size="small" disableElevation onClick={markAllNotificationsAsRead}>
+                                전체 알림 읽음
+                              </Button>
+                              <Button size="small" disableElevation onClick={deleteAllUnreadNotifications}>
+                                전체 알림 삭제
+                              </Button>
+                            </>
+                          ) : (
+                            <Button size="small" disableElevation onClick={deleteAllReadNotifications}>
+                              전체 알림 삭제
+                            </Button>
+                          )}
+                        </Box>
+                      </Grid>
+                    </Grid>
+                  </MainCard>
+                )}
+              </Paper>
+            </Transitions>
+          </ClickAwayListener>
+        )}
+      </Popper>
+    </Box>
   );
 }
 


### PR DESCRIPTION
## 🛠️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

<br/>

## 💾 반영 브랜치
notification-url -> dev

<br/>

## 👨‍🔧 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
- **AS-IS**
1. 실시간으로 알림 업데이트되는지 확인(기존 dev에서 안되었음)
2. 백에서 읽은 알림 및 안 읽은 알림 전체 삭제 메서드 추가
3. 프론트에서 셀렉트창에 따라 읽은 알림 및 안 읽은 알림에 대한 삭제 배치 및  테스트 완료
4. 알림 클릭 시 dev 배포 주소로의 변경 (이 부분은 Merge된 dev를 봐야 테스트를 해볼 수 있을 거 같음) 
 
- **TO-BE**
소소한 백 및 프론트 리팩토링 및 ppt 제작
  <br />

## 🎨 이미지 첨부
<!-- 이미지 첨부는 자유 입니다. 하실분은 하시고 안하실 분은 안하셔도 됩니다. -->
<img src="파일주소" width="50%" height="50%"/>
<br/>

## 👨‍💻 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트
<br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>
